### PR TITLE
Android 15 Linker Flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,13 @@ if(WIN32)
     target_link_libraries(enet6 PRIVATE winmm ws2_32)
 endif()
 
+if(ANDROID AND BUILD_SHARED_LIBS)
+    target_link_options(enet6 PRIVATE
+        "-Wl,-z,max-page-size=16384"
+        "-Wl,-z,common-page-size=16384"
+    )
+endif()
+
 # Installation
 include(GNUInstallDirs)
 install(TARGETS enet6

--- a/xmake.lua
+++ b/xmake.lua
@@ -40,6 +40,11 @@ target("enet6", function ()
         add_defines("ENET_DLL", { public = true })
     end
 
+    if is_plat("android") then
+        add_shflags("-Wl,-z,max-page-size=16384", {force = true})
+        add_shflags("-Wl,-z,common-page-size=16384", {force = true})
+    end
+
     if is_plat("windows", "mingw") then
         add_syslinks("winmm", "ws2_32", { public = true })
     else


### PR DESCRIPTION
I'm working on a Unity project and noticed this warning when importing the Android shared library:

<img width="615" height="359" alt="image" src="https://github.com/user-attachments/assets/24ccc107-0556-4aee-a921-42b332b17218" />

This PR adds the recommended Android linker flags:

- `-Wl,-z,max-page-size=16384`
- `-Wl,-z,common-page-size=16384`

More info here:
https://developer.android.com/guide/practices/page-sizes
